### PR TITLE
rewrite npcast and pdacast

### DIFF
--- a/pyecharts/base.py
+++ b/pyecharts/base.py
@@ -346,25 +346,11 @@ class Base(object):
             Numpy data -> ndarray
         :return:
         """
-        _np = npdata
-        if isinstance(npdata, numpy.ndarray):
-            if npdata.ndim == 1:
-                try:
-                    _npvalue = [float(v) for v in _np]
-                except:
-                    _npvalue = [str(v) for v in _np]
-            else:
-                try:
-                    _npvalue = []
-                    for _n in _np:
-                        _lst = [float(v) for v in _n]
-                        _npvalue.append(_lst)
-                except:
-                    _npvalue = []
-                    for _n in _np:
-                        _lst = [str(v) for v in _n]
-                        _npvalue.append(_lst)
-            return _npvalue
+        try:
+            _npvalue = npdata.astype(float).tolist()
+        except:
+            _npvalue = npdata.astype(str).tolist()
+        return _npvalue
 
     @staticmethod
     def pdcast(pddata):
@@ -376,28 +362,17 @@ class Base(object):
             Pandas data -> Series or DataFrame
         :return:
         """
+        try:
+            _dtvalue = pddata.values.astype(float).tolist()
+        except:
+            _dtvalue = pddata.values.astype(str).tolist()
         if isinstance(pddata, pandas.DataFrame):
-            try:
-                _dtvalue = []
-                for value in pddata.values:
-                    _lst = [float(v) for v in value]
-                    _dtvalue.append(_lst)
-            except:
-                _dtvalue = []
-                for value in pddata.values:
-                    _lst = [str(v) for v in value]
-                    _dtvalue.append(_lst)
             return _dtvalue
-        if isinstance(pddata, pandas.Series):
-            try:
-                _pdvalue = [float(v) for v in pddata]
-            except:
-                _pdvalue = [str(v) for v in pddata]
-            try:
-                _pdattr = [float(v) for v in pddata.index]
-            except:
-                _pdattr = [str(v) for v in pddata.index]
-            return _pdattr, _pdvalue
+        try:
+            _pdattr = pddata.index.astype(float).tolist()
+        except:
+            _pdattr = pddata.index.astype(str).tolist()
+        return _pdattr, _dtvalue
 
     def _legend_visualmap_colorlst(self, is_visualmap=False, **kwargs):
         """ config legend，visualmap and colorlst component.


### PR DESCRIPTION
重写了一下npcast和pdcast，np.array自带astype 以及 tolist.

另外个人觉得直接适配pd.Series使用更方便，在pyecharts的基础上重载了add方法，将Series的名称识别为曲线名称。另外添加了一个add_df 方法，专门绘制 pd.DataFrame, 将各列视为pd.Series, 一起绘制。
事实上在pandas中，也有专门的pd.DataFrame.plot 和 pd.Series.plot. [https://github.com/xbanke/myecharts](url)