### PR TITLE
Extend the benefit of js page load optimizaiton to flask and django integrations

### DIFF
--- a/docs/django-demo/myechartsite/myfirstvis/templates/myfirstvis/pyecharts.html
+++ b/docs/django-demo/myechartsite/myfirstvis/templates/myfirstvis/pyecharts.html
@@ -4,47 +4,10 @@
 
 <head>
     <meta charset="utf-8">
-    <title>ECharts</title>
-    <script src="http://oog4yfyu0.bkt.clouddn.com/echarts.min.js"></script>
-    <script src="http://oog4yfyu0.bkt.clouddn.com/echarts-gl.js"></script>
-    <script type="text/javascript " src="http://echarts.baidu.com/gallery/vendors/echarts/map/js/china.js"></script>
-    <script type="text/javascript " src="http://echarts.baidu.com/gallery/vendors/echarts/map/js/world.js"></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/wordcloud.js"></script>
-    <!-- take you geo map here
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/anhui.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/aomen.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/beijing.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/chongqing.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/fujian.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/gansu.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/guangdong.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/guangxi.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/guizhou.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/hainan.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/hebei.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/heilongjiang.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/henan.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/hubei.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/hunan.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/jiangsu.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/jiangxi.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/jilin.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/liaoning.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/neimenggu.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/ningxia.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/qinghai.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/shangdong.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/shanghai.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/shanxi.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/sichuan.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/taiwan.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/tianjin.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/xianggang.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/xinjiang.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/xizang.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/yunnan.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/zhejiang.js "></script>
-    -->
+    <title>Proudly presented by PycCharts</title>
+	{% for jsfile_name in script_list %}
+    <script src="{{host}}/{{jsfile_name}}.js"></script>
+    {% endfor %}
 </head>
 
 <body>

--- a/docs/django-demo/myechartsite/myfirstvis/views.py
+++ b/docs/django-demo/myechartsite/myfirstvis/views.py
@@ -5,9 +5,12 @@ from django.template import loader
 
 def index(request):
     template = loader.get_template('myfirstvis/pyecharts.html')
-    context = {
-        "myechart": line3d()
-    }
+    l3d = line3d()
+    context = dict(
+        myechart=l3d.render_embed(),
+        host="https://jupyter-echarts.github.io/",
+        script_list=l3d.get_js_dependencies()
+    )
     return HttpResponse(template.render(context, request))
 
 
@@ -22,9 +25,11 @@ def line3d():
         y = (1 + 0.25 * math.cos(75 * _t)) * math.sin(_t)
         z = _t + 2.0 * math.sin(75 * _t)
         _data.append([x, y, z])
-    range_color = ['#313695', '#4575b4', '#74add1', '#abd9e9', '#e0f3f8', '#ffffbf',
-                   '#fee090', '#fdae61', '#f46d43', '#d73027', '#a50026']
+    range_color = [
+        '#313695', '#4575b4', '#74add1', '#abd9e9', '#e0f3f8', '#ffffbf',
+        '#fee090', '#fdae61', '#f46d43', '#d73027', '#a50026']
     line3d = Line3D("3D line plot demo", width=1200, height=600)
-    line3d.add("", _data, is_visualmap=True, visual_range_color=range_color, visual_range=[0, 30],
+    line3d.add("", _data, is_visualmap=True,
+               visual_range_color=range_color, visual_range=[0, 30],
                is_grid3D_rotate=True, grid3D_rotate_speed=180)
-    return line3d.render_embed()
+    return line3d

--- a/docs/django-demo/myechartsite/myfirstvis/views.py
+++ b/docs/django-demo/myechartsite/myfirstvis/views.py
@@ -1,6 +1,11 @@
 from __future__ import unicode_literals
+import math
+
 from django.http import HttpResponse
 from django.template import loader
+from pyecharts import Line3D
+
+from pyecharts.constants import DEFAULT_HOST
 
 
 def index(request):
@@ -8,16 +13,13 @@ def index(request):
     l3d = line3d()
     context = dict(
         myechart=l3d.render_embed(),
-        host="https://chfw.github.io/jupyter-echarts",
+        host=DEFAULT_HOST,
         script_list=l3d.get_js_dependencies()
     )
     return HttpResponse(template.render(context, request))
 
 
 def line3d():
-    from pyecharts import Line3D
-
-    import math
     _data = []
     for t in range(0, 25000):
         _t = t / 1000

--- a/docs/en-us/documentation.md
+++ b/docs/en-us/documentation.md
@@ -107,6 +107,39 @@ And rarely again unless you are a developer of pyecharts, you choose to remove t
 $ jupyter nbextensions uninstall echarts --user
 ```
 
+#### jupyter-notebook export problem
+
+Since 0.1.9.7, pyecharts has gone into offline mode, drawing without internet connection. Now, the charts in exported note book cannot be display as they have been put outside
+jupyter environment.
+
+So the solution is to add the following statement:
+
+```python
+...
+from pyecharts import online
+
+online()
+...
+```
+Above code will take javascripts from https://chfw.github.io/jupyter-echarts/echarts. If
+you cannot connect to github, you could clone https://github.com/chfw/jupyter-echarts. Then, you put `echarts` folder onto your own server. Here is a simple command to achieve it:
+
+```
+$ cd jupyter-echarts/echarts
+$ python -m http.server # for python 2, use python -m SimpleHTTPServer
+Serving HTTP on 0.0.0.0 port 8000 ...
+```
+
+Then, add localhost into previous python code:
+
+```python
+...
+from pyecharts import online
+
+online(host="http://localhost:8000)
+...
+```
+
 ### Python2 Coding Problem
 default code type is UTF-8, there's no problem in Python3, because Python3 have a good support in chinese. But in Python2, please use the following sentence to ensure avoiding wrong coding problem:
 ```

--- a/docs/flask-examples/server.py
+++ b/docs/flask-examples/server.py
@@ -1,19 +1,32 @@
+import random
+from pyecharts import Scatter3D
 from flask import Flask, render_template
+
+
 app = Flask(__name__)
 
 
 @app.route("/")
 def hello():
-    return render_template('pyecharts.html', myechart=scatter3d())
+    s3d = scatter3d()
+    script_host = "https://jupyter-echarts.github.io/"
+    return render_template('pyecharts.html',
+                           myechart=s3d.render_embed(),
+                           host=script_host,
+                           script_list=s3d.get_js_dependencies())
 
 
 def scatter3d():
-    from pyecharts import Scatter3D
-
-    import random
-    data = [[random.randint(0, 100), random.randint(0, 100), random.randint(0, 100)] for _ in range(80)]
-    range_color = ['#313695', '#4575b4', '#74add1', '#abd9e9', '#e0f3f8', '#ffffbf',
-                   '#fee090', '#fdae61', '#f46d43', '#d73027', '#a50026']
+    data = [generate_3d_random_point() for _ in range(80)]
+    range_color = [
+        '#313695', '#4575b4', '#74add1', '#abd9e9', '#e0f3f8', '#ffffbf',
+        '#fee090', '#fdae61', '#f46d43', '#d73027', '#a50026']
     scatter3D = Scatter3D("3D scattering plot demo", width=1200, height=600)
     scatter3D.add("", data, is_visualmap=True, visual_range_color=range_color)
     return scatter3D.render_embed()
+
+
+def generate_3d_random_point():
+    return [random.randint(0, 100),
+            random.randint(0, 100),
+            random.randint(0, 100)]

--- a/docs/flask-examples/server.py
+++ b/docs/flask-examples/server.py
@@ -1,5 +1,6 @@
 import random
 from pyecharts import Scatter3D
+from pyecharts.constants import DEFAULT_HOST
 from flask import Flask, render_template
 
 
@@ -9,10 +10,9 @@ app = Flask(__name__)
 @app.route("/")
 def hello():
     s3d = scatter3d()
-    script_host = "https://chfw.github.io/jupyter-echarts"
     return render_template('pyecharts.html',
                            myechart=s3d.render_embed(),
-                           host=script_host,
+                           host=DEFAULT_HOST,
                            script_list=s3d.get_js_dependencies())
 
 
@@ -23,7 +23,7 @@ def scatter3d():
         '#fee090', '#fdae61', '#f46d43', '#d73027', '#a50026']
     scatter3D = Scatter3D("3D scattering plot demo", width=1200, height=600)
     scatter3D.add("", data, is_visualmap=True, visual_range_color=range_color)
-    return scatter3D.render_embed()
+    return scatter3D
 
 
 def generate_3d_random_point():

--- a/docs/flask-examples/templates/pyecharts.html
+++ b/docs/flask-examples/templates/pyecharts.html
@@ -3,47 +3,10 @@
 
 <head>
     <meta charset="utf-8">
-    <title>ECharts</title>
-    <script src="http://oog4yfyu0.bkt.clouddn.com/echarts.min.js"></script>
-    <script src="http://oog4yfyu0.bkt.clouddn.com/echarts-gl.js"></script>
-    <script type="text/javascript " src="http://echarts.baidu.com/gallery/vendors/echarts/map/js/china.js"></script>
-    <script type="text/javascript " src="http://echarts.baidu.com/gallery/vendors/echarts/map/js/world.js"></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/wordcloud.js"></script>
-    <!-- take your own map here
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/anhui.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/aomen.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/beijing.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/chongqing.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/fujian.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/gansu.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/guangdong.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/guangxi.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/guizhou.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/hainan.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/hebei.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/heilongjiang.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/henan.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/hubei.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/hunan.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/jiangsu.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/jiangxi.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/jilin.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/liaoning.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/neimenggu.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/ningxia.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/qinghai.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/shangdong.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/shanghai.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/shanxi.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/sichuan.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/taiwan.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/tianjin.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/xianggang.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/xinjiang.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/xizang.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/yunnan.js "></script>
-    <script type="text/javascript " src="http://oog4yfyu0.bkt.clouddn.com/zhejiang.js "></script>
-    -->
+    <title>Proudly presented by ECharts</title>
+	{% for jsfile_name in script_list %}
+    <script src="{{host}}/{{jsfile_name}}.js"></script>
+    {% endfor %}
 </head>
 
 <body>

--- a/docs/zh-cn/documentation.md
+++ b/docs/zh-cn/documentation.md
@@ -120,6 +120,40 @@ $ jupyter nbextensions install echarts --user
 $ jupyter nbextension uninstall echarts --user
 ```
 
+#### jupyter-notebook输出问题
+
+自0.1.9.7起，pyecharts已经进入全部离线模式，也就是没有网络，也能画图。jupyter notebook输出后，你的notebook离开了jupyter环境，图片就不能显示了。
+为了解决这个问题，再画图之前，你可以多加两个语句：
+
+```python
+...
+from pyecharts import online
+
+online()
+...
+```
+
+这样，所有的脚本会从http://chfw.github.io/jupyter-echarts/echarts下载。如果你联不上github, 你
+可以先把https://github.com/chfw/jupyter-echarts克隆一下。然后在你自己的服务器上，把整个
+echarts挂上去。比如，我可以这样简单地做一下：
+
+```
+$ cd jupyter-echarts/echarts
+$ python -m http.server # for python 2, use python -m SimpleHTTPServer
+Serving HTTP on 0.0.0.0 port 8000 ...
+```
+
+然后，再把本地服务器加进前面的语句：
+
+```python
+...
+from pyecharts import online
+
+online(host="http://localhost:8000)
+...
+```
+
+
 ### Python2 编码问题
 默认的编码类型为 UTF-8，在 Python3 中是没什么问题的，Python3 对中文的支持好很多。但是在 Python2 中，请应用下面的语句，保证没有编码问题:
 ```

--- a/pyecharts/__init__.py
+++ b/pyecharts/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#coding=utf-8
+# coding=utf-8
 
 from pyecharts._version import __version__, __author__
 
@@ -33,3 +33,6 @@ from pyecharts.custom.timeline import Timeline
 
 # version
 from pyecharts._version import __version__
+
+# misc
+from pyecharts.template import online

--- a/pyecharts/base.py
+++ b/pyecharts/base.py
@@ -60,8 +60,11 @@ class Base(object):
         :param background_color:
             Background color of title, which is transparent by default.
             Color can be represented in RGB, for example 'rgb(128, 128, 128)'.
-            RGBA can be used when you need alpha channel, for example 'rgba(128, 128, 128, 0.5)'.
+            RGBA can be used when you need alpha channel,
+            for example 'rgba(128, 128, 128, 0.5)'.
             You may also use hexadecimal format, for example '#ccc'.
+        :param jshost:
+            custom javascript host for the particular chart only
         """
         self._option = {}
         self._width, self._height = width, height

--- a/pyecharts/base.py
+++ b/pyecharts/base.py
@@ -23,7 +23,8 @@ class Base(object):
                  subtitle_color="#aaa",
                  title_text_size=18,
                  subtitle_text_size=12,
-                 background_color="#fff"):
+                 background_color="#fff",
+                 jshost=None):
         """
 
         :param title:
@@ -98,7 +99,7 @@ class Base(object):
             legend=[{"data": []}],
             backgroundColor=background_color
         )
-        self._jshost = constants.DEFAULT_HOST
+        self._jshost = jshost if jshost else constants.CONFIGURATION['HOST']
         self._js_dependencies = {'echarts'}
         self._chart_id = uuid.uuid4().hex
 

--- a/pyecharts/base.py
+++ b/pyecharts/base.py
@@ -331,6 +331,12 @@ class Base(object):
                           myWidth=self._width, myHeight=self._height)
         return html
 
+    def get_js_dependencies(self):
+        """
+        Declare its javascript dependencies for embedding purpose
+        """
+        return template.produce_html_script_list(self._js_dependencies)
+
     def render(self, path="render.html"):
         """ Render the options dict, generate the html file
 

--- a/pyecharts/constants.py
+++ b/pyecharts/constants.py
@@ -2,7 +2,12 @@
 # coding=utf-8
 from __future__ import unicode_literals
 
-DEFAULT_HOST = '/nbextensions/echarts'
+
+DEFAULT_HOST = 'https://chfw.github.io/jupyter-echarts/echarts'
+
+CONFIGURATION = dict(
+    HOST='/nbextensions/echarts'
+)
 
 DEFAULT_JS_LIBRARIES = dict(
     echarts='echarts.min',

--- a/pyecharts/custom/page.py
+++ b/pyecharts/custom/page.py
@@ -2,7 +2,7 @@
 # coding=utf-8
 
 from pyecharts import template
-from pyecharts.constants import DEFAULT_HOST
+import pyecharts.constants as constants
 from pyecharts.template import (
     produce_require_configuration,
     produce_html_script_list)
@@ -10,9 +10,9 @@ from pyecharts.template import (
 
 class Page(object):
 
-    def __init__(self):
+    def __init__(self, jshost=None):
         self.__charts = []
-        self._jshost = DEFAULT_HOST
+        self._jshost = jshost if jshost else constants.CONFIGURATION['HOST']
 
     def add(self, achart_or_charts):
         """

--- a/pyecharts/custom/page.py
+++ b/pyecharts/custom/page.py
@@ -9,8 +9,16 @@ from pyecharts.template import (
 
 
 class Page(object):
-
+    """
+    A composite object to present multiple charts vertically in a single page
+    """
     def __init__(self, jshost=None):
+        """
+        Constructor
+
+        :param jshost:
+            custom javascript host for the particular chart only
+        """
         self.__charts = []
         self._jshost = jshost if jshost else constants.CONFIGURATION['HOST']
 

--- a/pyecharts/custom/page.py
+++ b/pyecharts/custom/page.py
@@ -54,6 +54,13 @@ class Page(object):
             chart_content += chart.render_embed()
         return chart_content
 
+    def get_js_dependencies(self):
+        """
+        Declare its javascript dependencies for embedding purpose
+        """
+        unordered_js_dependencies = self._merge_dependencies()
+        return produce_html_script_list(unordered_js_dependencies)
+
     def _repr_html_(self):
         """
 

--- a/pyecharts/template.py
+++ b/pyecharts/template.py
@@ -7,7 +7,8 @@ import re
 import sys
 import codecs
 from jinja2 import Environment, FileSystemLoader
-from pyecharts.constants import DEFAULT_JS_LIBRARIES
+import pyecharts.constants as constants
+
 
 PY2 = sys.version_info[0] == 2
 
@@ -92,7 +93,9 @@ def produce_require_configuration(dependencies, jshost):
     _d = ensure_echarts_is_in_the_front(dependencies)
     # if no nick name register, we treat the location as location.js
     require_conf_items = [
-        "'%s': '%s/%s'" % (key, jshost, DEFAULT_JS_LIBRARIES.get(key, key))
+        "'%s': '%s/%s'" % (key,
+                           jshost,
+                           constants.DEFAULT_JS_LIBRARIES.get(key, key))
         for key in _d]
     require_libraries = ["'%s'" % key for key in _d]
     return dict(
@@ -109,7 +112,7 @@ def produce_html_script_list(dependencies):
     """
     _d = ensure_echarts_is_in_the_front(dependencies)
     script_list = [
-        '%s' % DEFAULT_JS_LIBRARIES.get(key, key)
+        '%s' % constants.DEFAULT_JS_LIBRARIES.get(key, key)
         for key in _d]
     return script_list
 
@@ -132,3 +135,7 @@ def ensure_echarts_is_in_the_front(dependencies):
     else:
         raise Exception("No js library found. Nothing works!")
     return dependencies
+
+
+def online(host=constants.DEFAULT_HOST):
+    constants.CONFIGURATION['HOST'] = host

--- a/pyecharts/templates/base.html
+++ b/pyecharts/templates/base.html
@@ -4,11 +4,11 @@
 <head>
     <meta charset="utf-8">
     <title>ECharts</title>
-	<!-- build -->
-	{% for jsfile_name in script_list %}
+    <!-- build -->
+    {% for jsfile_name in script_list %}
     <script src="js/echarts/{{jsfile_name}}.js"></script>
-	{% endfor %}
-	<!-- endbuild -->
+    {% endfor %}
+    <!-- endbuild -->
 </head>
 
 <body>

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -7,6 +7,7 @@ import json
 import pandas as pd
 import numpy as np
 
+from nose.tools import eq_
 from pyecharts import Bar
 
 
@@ -59,6 +60,14 @@ def test_notebook_component():
     assert json_encoded_title in html
     assert "myChart" in html
     assert bar._chart_id in html
+
+
+def test_base_get_js_dependencies():
+
+    bar = create_a_bar(TITLE)
+    dependencies = bar.get_js_dependencies()
+    expected = ['echarts.min']
+    eq_(dependencies, expected)
 
 
 def test_numpy_array():

--- a/test/test_online_feature.py
+++ b/test/test_online_feature.py
@@ -1,0 +1,48 @@
+# coding=utf-8
+from __future__ import unicode_literals
+
+import pyecharts.constants as constants
+from pyecharts import Bar, Page
+from pyecharts.template import online
+from nose.tools import eq_
+
+
+DEFAULT_HOST = 'https://chfw.github.io/jupyter-echarts/echarts'
+
+
+def test_online():
+    old_host = constants.CONFIGURATION['HOST']
+    online()
+    eq_(constants.CONFIGURATION['HOST'], DEFAULT_HOST)
+    constants.CONFIGURATION['HOST'] = old_host
+
+
+def test_online_with_chart():
+    old_host = constants.CONFIGURATION['HOST']
+    online()
+    attr = ["衬衫", "羊毛衫", "雪纺衫", "裤子", "高跟鞋", "袜子"]
+    v1 = [5, 20, 36, 10, 75, 90]
+    v2 = [10, 25, 8, 60, 20, 80]
+    bar = Bar("柱状图数据堆叠示例")
+    bar.add("商家A", attr, v1, is_stack=True)
+    bar.add("商家B", attr, v2, is_stack=True)
+    html = bar._repr_html_()
+    assert DEFAULT_HOST in html
+    constants.CONFIGURATION['HOST'] = old_host
+
+
+def test_online_with_page():
+    old_host = constants.CONFIGURATION['HOST']
+    online()
+    page = Page()
+    attr = ["衬衫", "羊毛衫", "雪纺衫", "裤子", "高跟鞋", "袜子"]
+    v1 = [5, 20, 36, 10, 75, 90]
+    v2 = [10, 25, 8, 60, 20, 80]
+    bar = Bar("柱状图数据堆叠示例")
+    bar.add("商家A", attr, v1, is_stack=True)
+    bar.add("商家B", attr, v2, is_stack=True)
+    page.add(bar)
+
+    html = page._repr_html_()
+    assert DEFAULT_HOST in html
+    constants.CONFIGURATION['HOST'] = old_host

--- a/test/test_online_feature.py
+++ b/test/test_online_feature.py
@@ -31,18 +31,57 @@ def test_online_with_chart():
     constants.CONFIGURATION['HOST'] = old_host
 
 
+def test_chart_with_custom_host():
+    local_host = 'http://localhost:8000'
+    attr = ["衬衫", "羊毛衫", "雪纺衫", "裤子", "高跟鞋", "袜子"]
+    v1 = [5, 20, 36, 10, 75, 90]
+    bar = Bar("柱状图数据堆叠示例", jshost=local_host)
+    bar.add("商家A", attr, v1, is_stack=True)
+    html = bar._repr_html_()
+    assert local_host in html
+    assert constants.CONFIGURATION['HOST'] != local_host
+
+
+def test_in_event_of_overly_configured_custom_url_is_precedent():
+    old_host = constants.CONFIGURATION['HOST']
+    local_host = 'http://localhost:8000'
+    online()
+    attr = ["衬衫", "羊毛衫", "雪纺衫", "裤子", "高跟鞋", "袜子"]
+    v1 = [5, 20, 36, 10, 75, 90]
+    v2 = [10, 25, 8, 60, 20, 80]
+    bar = Bar("柱状图数据堆叠示例", jshost=local_host)
+    bar.add("商家A", attr, v1, is_stack=True)
+    bar.add("商家B", attr, v2, is_stack=True)
+    html = bar._repr_html_()
+    assert DEFAULT_HOST not in html
+    assert local_host in html
+    constants.CONFIGURATION['HOST'] = old_host
+
+
 def test_online_with_page():
     old_host = constants.CONFIGURATION['HOST']
     online()
     page = Page()
     attr = ["衬衫", "羊毛衫", "雪纺衫", "裤子", "高跟鞋", "袜子"]
     v1 = [5, 20, 36, 10, 75, 90]
-    v2 = [10, 25, 8, 60, 20, 80]
     bar = Bar("柱状图数据堆叠示例")
     bar.add("商家A", attr, v1, is_stack=True)
-    bar.add("商家B", attr, v2, is_stack=True)
     page.add(bar)
 
     html = page._repr_html_()
     assert DEFAULT_HOST in html
     constants.CONFIGURATION['HOST'] = old_host
+
+
+def test_page_with_custom_host():
+    local_host = 'http://localhost:8000'
+    page = Page(jshost=local_host)
+    attr = ["衬衫", "羊毛衫", "雪纺衫", "裤子", "高跟鞋", "袜子"]
+    v1 = [5, 20, 36, 10, 75, 90]
+    bar = Bar("柱状图数据堆叠示例")
+    bar.add("商家A", attr, v1, is_stack=True)
+    page.add(bar)
+
+    html = page._repr_html_()
+    assert local_host in html
+    assert constants.CONFIGURATION['HOST'] != local_host

--- a/test/test_page.py
+++ b/test/test_page.py
@@ -7,8 +7,8 @@ import codecs
 from pyecharts import (
     Bar, Scatter3D, Line, Pie, Map,
     Kline, Radar, WordCloud, Liquid)
-from pyecharts import Page, online
-import pyecharts.constants as constants
+from pyecharts import Page
+from nose.tools import eq_
 
 
 def create_three():
@@ -56,6 +56,13 @@ def test_two_bars():
         echarts_position = actual_content.find('exports.echarts')
         guangdong_position = actual_content.find(json.dumps('广东'))
         assert echarts_position < guangdong_position
+
+
+def test_page_get_js_dependencies():
+    page = create_three()
+    dependencies = page.get_js_dependencies()
+    expected = ['echarts.min', 'guangdong', 'echarts-gl.min']
+    eq_(dependencies, expected)
 
 
 def test_page_embed():

--- a/test/test_page.py
+++ b/test/test_page.py
@@ -7,7 +7,8 @@ import codecs
 from pyecharts import (
     Bar, Scatter3D, Line, Pie, Map,
     Kline, Radar, WordCloud, Liquid)
-from pyecharts import Page
+from pyecharts import Page, online
+import pyecharts.constants as constants
 
 
 def create_three():

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -2,6 +2,7 @@
 # coding=utf-8
 from __future__ import unicode_literals
 
+
 from nose.tools import eq_, raises
 from pyecharts.template import (
     freeze_js,


### PR DESCRIPTION
And allow user to specify a javascript host in issue #107 so that exported notebook would still have the charts display. The default host is: https://chfw.github.com/jupyter-echarts/echarts, which should be as stable as github and be as widely reachable as github. User is given the choice to use their own host but is recommended to host jupyter-echarts/echarts as it is. 

And update jupyter-echarts to 1.0.1 which brings in echart 3.7.0, which was released yesterday. so please do `git submodule update` after merge.