### PR TITLE
Added 212 countries and regions.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
     * [issue#22](https://github.com/chenjiandongx/pyecharts/issues/22) 为散点图新增 `extra_data` 参数，可以为数据新增除 x y 轴外的其他维度
     * 为 markPoint 新增自定义标记点功能
     * 为 visualMap 新增 `visual_dimension` 参数，可以指定 visualmap 映射到哪个数据维度
+    * 加入[212个国家和地区](https://github.com/chfw/echarts-countries-js#featuring-citiesor-for-single-download)。
 
 * ### version 0.2.4 - 2017.9.8（Current）
     

--- a/pyecharts/_version.py
+++ b/pyecharts/_version.py
@@ -1,2 +1,2 @@
-__version__ = '0.2.4'
+__version__ = '0.2.5'
 __author__ = 'chenjiandongx'


### PR DESCRIPTION
新加212个国家地区。比如

印度

![screenshot from 2017-09-25 00-33-26](https://user-images.githubusercontent.com/4280312/30787862-509fee02-a18a-11e7-995d-22feaa7808e1.png)

日本
![screenshot from 2017-09-25 00-43-23](https://user-images.githubusercontent.com/4280312/30787873-9056b788-a18a-11e7-892d-1a495e09354e.png)

埃及
![image](https://user-images.githubusercontent.com/4280312/30787904-005caa24-a18b-11e7-8d41-54a06d62a813.png)

地图来自https://github.com/pissang/starbucks/issues/2