### PR TITLE
turn show_config into valid javascript object notation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,9 +13,10 @@
     * [issue#201](https://github.com/chenjiandongx/pyecharts/issues/201) 为 Bar 图新增 `bar_category_gap` 参数，提供绘制直方图的方案
     * [issue#208](https://github.com/chenjiandongx/pyecharts/issues/208) 为 dataZoom 通用配置项 `datazoom_type` 新增类型 'both'（同时拥有 'slider' 以及 'inside')
     * [issue#208](https://github.com/chenjiandongx/pyecharts/issues/208) 为 HeatMap 图新增 **日历热力图**
-    
+
     #### Changed
     * 将 label 通用配置项的 `is_emphasis` 参数更改为 `is_label_emphasis`
+	* show_config() 修改用JSON显示
 
     #### Fixed
     * [issue#195](https://github.com/chenjiandongx/pyecharts/issues/195) 修复 HeatMap 图配置 x、y 轴属性无效的问题

--- a/pyecharts/base.py
+++ b/pyecharts/base.py
@@ -5,7 +5,6 @@ import json
 import uuid
 import random
 import datetime
-from pprint import pprint
 
 from pyecharts.option import get_all_options
 from pyecharts import template
@@ -311,7 +310,7 @@ class Base(object):
 
     def show_config(self):
         """ Print all options of charts"""
-        pprint(self._option)
+        print(json_dumps(self._option, indent=4))
 
     @property
     def options(self):

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -2,6 +2,8 @@
 # coding=utf-8
 from __future__ import unicode_literals
 
+import os
+import sys
 import json
 import codecs
 
@@ -105,3 +107,24 @@ def test_echarts_position_in_render_html():
     with codecs.open('render.html', 'r', 'utf-8') as f:
         actual_content = f.read()
         assert TITLE in actual_content
+
+
+def test_show_config():
+    stdout_ = sys.stdout
+    captured_stdout = 'stdout.txt'
+    try:
+        with open(captured_stdout, 'w') as f:
+            sys.stdout = f
+            bar = create_a_bar("new")
+            bar.show_config()
+    except Exception as e:
+        # whatever happens, continue and restore stdout
+        print(e)
+    sys.stdout = stdout_
+    with open(captured_stdout, 'r') as f:
+        content = f.read()
+        assert 'None' not in content
+        assert 'null' in content
+        assert 'false' in content
+        assert 'False' not in content
+    os.unlink(captured_stdout)


### PR DESCRIPTION
Other than debugging purpose, the output of show_config() has no practical usage becuase it is in python notation, `True`, `False` and `None`
<img width="365" alt="screen shot 2017-10-13 at 22 13 57" src="https://user-images.githubusercontent.com/4280312/31566783-0a88bc1c-b064-11e7-882c-c25efecee296.png">
<img width="334" alt="screen shot 2017-10-13 at 22 14 33" src="https://user-images.githubusercontent.com/4280312/31566784-0c4c068a-b064-11e7-899e-50165cd5863e.png">

With this PR, you can copy them and paste into html and javascript, and reuse the config:
<img width="219" alt="screen shot 2017-10-13 at 22 15 01" src="https://user-images.githubusercontent.com/4280312/31566835-4a0fcd9e-b064-11e7-83bd-aa455197d587.png">

For example:

```
const echarts = require('node-echarts');
require("echarts/map/js/world.js");

var option = {"backgroundColor":"#fff","legend":[{"data":[""],"textStyle":{"fontSize":12,"color":"#333"},"orient":"horizontal","top":"top","left":"center","show":true,"selectedMode":"multiple"}],"series":[{"typ\
e":"map","name":"","symbol":"circle","label":{"normal":{"show":false,"position":"top","textStyle":{"color":"#000","fontSize":12},"formatter":null},"emphasis":{"show":true}},"mapType":"world","data":[{"name":"Ch\
ina","value":95.1},{"name":"Canada","value":23.2},{"name":"Brazil","value":43.3},{"name":"Russia","value":66.4},{"name":"United States","value":88.5}],"roam":true}],"tooltip":{"trigger":"item","triggerOn":"mous\
emove|click","axisPointer":{"type":"line"},"formatter":null,"textStyle":{"color":"#fff","fontSize":14}},"series_id":1362132,"toolbox":{"show":true,"orient":"vertical","left":"95%","top":"center","feature":{"sav\
eAsImage":{"show":true,"title":"下载图片"},"restore":{"show":true},"dataView":{"show":true}}},"title":[{"text":"World Map Example","subtext":"","left":"auto","top":"auto","textStyle":{"color":"#000","fontSize":\
18},"subtextStyle":{"color":"#aaa","fontSize":12}}],"color":["#c23531","#2f4554","#61a0a8","#d48265","#749f83","#ca8622","#bda29a","#6e7074","#546570","#c4ccd3","#f05b72","#ef5b9c","#f47920","#905a3d","#fab27b"\
,"#2a5caa","#444693","#726930","#b2d235","#6d8346","#ac6767","#1d953f","#6950a1","#918597","#f6f5ec"],"visualMap":{"type":"continuous","min":0,"max":100,"text":["high","low"],"textStyle":{"color":"#000"},"inRan\
ge":{"color":["#50a3ba","#eac763","#d94e5d"]},"calculable":true,"splitNumber":5,"dimension":null,"orient":"vertical","left":"left","top":"bottom"}};
echarts({
  path: 'world.png',
  option: option,
  width: 600,
  height: 400});
```

![pie](https://user-images.githubusercontent.com/4280312/31059737-7153e99e-a6ff-11e7-9dc8-5b2ec59be76c.png)

reference: https://github.com/suxiaoxin/node-echarts/issues/9